### PR TITLE
test: trigger Spectral lint failure

### DIFF
--- a/artifacts/apis/echo-api/specification.yaml
+++ b/artifacts/apis/echo-api/specification.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.1
 info:
   title: ""
+  description: "Test for Spectral lint failure"
   version: '1.0'
 servers:
   - url: https://apim-devon-dev-eastus2-uxs.azure-api.net/echo


### PR DESCRIPTION
Testing Spectral linter with broken OpenAPI title field (empty string) to verify quality gates work properly.